### PR TITLE
add PHP script start and ending

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ composer require rosell-dk/webp-convert-cloud-service
 Here is an example to get started with:
 
 ```php
+<?php
 require 'vendor/autoload.php';
 
 use \WebPConvertCloudService\WebPConvertCloudService;
@@ -53,6 +54,7 @@ $options = [
 
 $wpc = new WebPConvertCloudService();
 $wpc->handleRequest($options);
+?>
 
 ```
 


### PR DESCRIPTION
A friend of mine tried setting up this project. He simply forgot the PHP script start and ending and wondered why his API endpoint wasn't working. So I suggest to add those in the README.md file to avoid problems like that in the future.
```php
 <?php
// PHP code goes here
?>
```